### PR TITLE
Fixed error due to slashes interfering with BEDS.

### DIFF
--- a/beadm
+++ b/beadm
@@ -161,7 +161,7 @@ __be_new() { # 1=SOURCE 2=TARGET
         done << EOF
 $( zfs get -o name,property,value -s local,received -H all ${FS} | awk '!/[\t ]canmount[\t ]/' )
 EOF
-        DATASET=$( echo ${FS} | awk '{print $1}' | sed -E s:"^${POOL}\/${BEDS}\/${SOURCE##*/}":"${POOL}\/${BEDS}\/${2##*/}":g )
+        DATASET=$( echo ${FS} | awk '{print $1}' | sed -E s#"^${POOL}\/${BEDS}\/${SOURCE##*/}"#"${POOL}\/${BEDS}\/${2##*/}"#g )
         if [ "${OPTS}" = "-o = " ]
         then
           local OPTS=""

--- a/beadm
+++ b/beadm
@@ -161,7 +161,7 @@ __be_new() { # 1=SOURCE 2=TARGET
         done << EOF
 $( zfs get -o name,property,value -s local,received -H all ${FS} | awk '!/[\t ]canmount[\t ]/' )
 EOF
-        DATASET=$( echo ${FS} | awk '{print $1}' | sed -E s/"^${POOL}\/${BEDS}\/${SOURCE##*/}"/"${POOL}\/${BEDS}\/${2##*/}"/g )
+        DATASET=$( echo ${FS} | awk '{print $1}' | sed -E s:"^${POOL}\/${BEDS}\/${SOURCE##*/}":"${POOL}\/${BEDS}\/${2##*/}":g )
         if [ "${OPTS}" = "-o = " ]
         then
           local OPTS=""


### PR DESCRIPTION
When using '/' to delimit sed argument alternatively named pools get errors.

e.g. 
With a pool where BEDS is set in beadm.conf to 'BEDS=system/ROOT'

and a boot environment is created
`$ beadm create test-be`

The following error occurs:
`sed: -e expression #1, char 32: unknown option to`s'`

Replaced sed delimiter with ':'.
